### PR TITLE
Add Affiliation Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   `colorconcludingresponseframe`.
 - Each comment now automatically sets a bookmark in the PDF (using the
   `bookmark` option of `tcolorbox`).
-- Add `\affiliations` to `\maketitle` to display affiliations in the cover letter, associated with `\affil` and `\affiliation` definitions that can be used in `\author` and `\affiliations` commands.
+- Add `\affil` to `\maketitle` to display affiliations in the cover letter, associated with `\affil` definitions that can be used in `\author` and `\affiliations` commands.
 
 
 ## [2.0.1] - 2024-06-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   `colorconcludingresponseframe`.
 - Each comment now automatically sets a bookmark in the PDF (using the
   `bookmark` option of `tcolorbox`).
+- Add `\affiliations` to `\maketitle` to display affiliations in the cover letter, associated with `\affil` and `\affiliation` definitions that can be used in `\author` and `\affiliations` commands.
 
 
 ## [2.0.1] - 2024-06-25

--- a/README.md
+++ b/README.md
@@ -31,7 +31,11 @@ Place these commands before `\begin{document}`.
 
 ```latex
 \title{Title of the Manuscript}
-\author{Author One, Author Two, and Author Three}
+\author{Author One\affil{1}, Author Two\affil{1,*} and Author Three\affil{2}}
+\affiliations{
+    \affiliation{1}{Affiliation 1}
+    \affiliation{2}{Affiliation 2}
+}
 \journal{Name of the Journal}
 \manuscript{ID-of-the-Manuscript}
 \editorname{Name of the Editor}

--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ Place these commands before `\begin{document}`.
 
 ```latex
 \title{Title of the Manuscript}
-\author{Author One\affil{1}, Author Two\affil{1,*} and Author Three\affil{2}}
+\author{Author One\affil{1}{}, Author Two\affil{1,*}{} and Author Three\affil{2}{}}
 \affiliations{
-    \affiliation{1}{Affiliation 1}
-    \affiliation{2}{Affiliation 2}
+    \affil{1}{Affiliation 1}
+    \affil{2}{Affiliation 2}
 }
 \journal{Name of the Journal}
 \manuscript{ID-of-the-Manuscript}

--- a/review_response.tex
+++ b/review_response.tex
@@ -20,7 +20,11 @@
 
 
 \title{My Awesome Paper Title}
-\author{Donald Duck and Mickey Mouse}
+\author{Donald Duck\affil{1,*} and Mickey Mouse\affil{2}}
+\affiliations{
+	\affiliation{1}{Department of Quacking, Duck University, Duckburg, USA}
+	\affiliation{2}{Department of Mousing, Mouse University, Mouseton, USA}
+}
 \journal{IEEE Transactions on Wireless Communications}
 \manuscript{TWC-2020-X}
 \editorname{Dr. Doom}

--- a/review_response.tex
+++ b/review_response.tex
@@ -20,10 +20,10 @@
 
 
 \title{My Awesome Paper Title}
-\author{Donald Duck\affil{1,*} and Mickey Mouse\affil{2}}
+\author{Donald Duck\affil{1,*}{} and Mickey Mouse\affil{2}{}}
 \affiliations{
-	\affiliation{1}{Department of Quacking, Duck University, Duckburg, USA}
-	\affiliation{2}{Department of Mousing, Mouse University, Mouseton, USA}
+	\affil{1}{Department of Quacking, Duck University, Duckburg, USA}
+	\affil{2}{Department of Mousing, Mouse University, Mouseton, USA}
 }
 \journal{IEEE Transactions on Wireless Communications}
 \manuscript{TWC-2020-X}

--- a/reviewresponse.cls
+++ b/reviewresponse.cls
@@ -59,10 +59,28 @@
 \setcounter{revcomment}{0}
 %%%
 
-%%% Definitions
-\def\affil#1{$^{#1}$\ignorespaces}
-\def\affiliation#1#2{\vskip-.5\parskip\relax{\centering{\footnotesize
-$^{#1}$#2\relax}\vskip-\parskip}}
+%%% Affiliation Display Settings
+% Affiliation display
+% 0=no display, 1=number only, 2=full
+\newcount\@affilmode
+\@affilmode=0
+\newcommand{\setaffilhide}{\@affilmode=0}
+\newcommand{\setaffilnumber}{\@affilmode=1}
+\newcommand{\setaffilfull}{\@affilmode=2}
+\setaffilhide
+
+\def\affil#1#2{\ifcase\@affilmode
+	\relax
+\or
+	\relax{$^{#1}$\ignorespaces\relax}
+\or
+	\vskip-.5\parskip\relax{\centering{\footnotesize
+	$^{#1}$#2\relax}\vskip-\parskip}
+\else
+	% raise error
+	\@latex@error{Invalid \string\@affilmode value: \the\@affilmode}\@ehc
+\fi}
+%%%
 
 %%% Commands
 \renewcommand*{\maketitle}{%
@@ -80,9 +98,9 @@ $^{#1}$#2\relax}\vskip-\parskip}}
 			
 			\large{by}
 			
-			{\large{\@author}}
-
-			{\large{\@affiliations}}
+			\setaffilnumber{\large{\@author}}
+			
+			\setaffilfull{\large{\@affiliations}}\setaffilhide
 		\end{center}
 	\end{titlepage}
 }

--- a/reviewresponse.cls
+++ b/reviewresponse.cls
@@ -20,6 +20,8 @@
 \newcommand*{\@editorname}{}
 \newcommand*{\manuscript}[1]{\renewcommand*{\@manuscript}{#1}}
 \newcommand*{\@manuscript}{}
+\newcommand*{\affiliations}[1]{\renewcommand*{\@affiliations}{#1}}
+\newcommand*{\@affiliations}{}
 
 \newcommand*{\thetitle}{\@title}
 \newcommand*{\theauthor}{\@author}
@@ -57,6 +59,11 @@
 \setcounter{revcomment}{0}
 %%%
 
+%%% Definitions
+\def\affil#1{$^{#1}$\ignorespaces}
+\def\affiliation#1#2{\vskip-.5\parskip\relax{\centering{\footnotesize
+$^{#1}$#2\relax}\vskip-\parskip}}
+
 %%% Commands
 \renewcommand*{\maketitle}{%
 	\begin{titlepage}
@@ -74,6 +81,8 @@
 			\large{by}
 			
 			{\large{\@author}}
+
+			{\large{\@affiliations}}
 		\end{center}
 	\end{titlepage}
 }


### PR DESCRIPTION
First of all, thank you for this project, I actually plan to use it in my next response letter to reviewers :)

I thought it might be useful to add affiliations supports in certain cases, especially when there are too many authors from different affiliations. 

The implementation is largely adopted from [AGU Official Templates](https://www.overleaf.com/gallery/tagged/agu-official), in such way that I can copy-paste most of the author/affiliation stuff from an AGU paper directly into this template. But I guess it is still easy to use for general users.